### PR TITLE
Batch fetch meetings, associated contacts and create actions

### DIFF
--- a/Domain.js
+++ b/Domain.js
@@ -58,6 +58,10 @@ const DomainSchema = new Schema({
         refreshToken: String,
         lastPulledDate: Date,
         lastPulledDates: {
+          meetings: {
+            type: Date,
+            default: moment().subtract(4, 'year').toISOString()
+          },
           companies: {
             type: Date,
             default: moment().subtract(4, 'year').toISOString()


### PR DESCRIPTION
# Debrief

## Quality and readability
* `worker.js` got quite big - could be split into separate parts for processing companies, contacts and meetings
* there is quite a bit of code duplication - e.g. exponential retries could be extracted for an utility function that could be reused
* quite a few nested and chained method calls (e.g. `(await (await hubspotClient.apiRequest({...}).json())`) - creating separate variables could help for readability
* there are a few lines of code that I'd investigate (I can't guess the intention behind it), e.g.:

```
if (!offsetObject?.after) {
      hasMore = false;
      break;
    } else if (offsetObject?.after >= 9900) {
      offsetObject.after = 0;
      offsetObject.lastModifiedDate = new Date(data[data.length - 1].updatedAt).valueOf();
    }
```
Why are we reseting after >= 9900 here?


```
      q.push({
        actionName: isCreated ? 'Company Created' : 'Company Updated',
        actionDate: new Date(isCreated ? company.createdAt : company.updatedAt) - 2000,
        ...actionTemplate
      });
```
Why are we subtracting 2000 from the date here?


## Project architecture
* it seems the project is well formed and most probably intended to be run with serverless compute like AWS Lambda or Cloudflare Workers
* if the above is the case I am not sure if having express.js (`server.js`) file is needed


## Performance
* the biggest pain point is the number of API calls that needs to be issued to hubspot - this should be minimized as much as possible, e.g. by using batch endpoints
* creating a queue with concurrency value of 100000000 may not have the intended impact as compute resources are still limited - I'd investigate how this value impacts the performance


